### PR TITLE
fix uname on linux

### DIFF
--- a/purr
+++ b/purr
@@ -487,6 +487,8 @@ fi
 # we are sending TTY output, which makes fzf unhappy. 
 if command -v pbcopy &> /dev/null && [ -z $SSH_TTY ]; then
     pbcopy_purr="$(which pbcopy)"
+elif command -v wl-copy &> /dev/null && [ $XDG_SESSION_TYPE = "wayland" ]; then
+    pbcopy_purr="wl-copy"
 elif command -v xsel &> /dev/null && [ ! -z $DISPLAY ]; then
     pbcopy_purr="xsel --clipboard --input"
 elif command -v purr_osc52_copy &> /dev/null; then

--- a/purr
+++ b/purr
@@ -471,7 +471,7 @@ elif [ $(uname -s) = "Darwin" ]; then
         fzf_purr="purr_fzf_darwin_amd64"
     fi
 elif [ $(uname -s) = "Linux" ]; then
-    if [ $(arch) = "x86_64" ]; then
+    if [ $(uname -m) = "x86_64" ]; then
         fzf_purr="purr_fzf_linux_x86_64"
     fi
 fi


### PR DESCRIPTION
`arch` is not always available. Fallback to `uname -m`