### PR TITLE
Add file tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Support for Windows may be provided in future, but is not a current priority.
 * [perl](https://www.perl.org/)
 
 ### Guide
-`purr` includes a simple tool to help select the device serial from `adb devices`, or can read from the `$ANDROID_SERIAL` environment variable if set. Otherwise, `purr` has six command-line parameters:
+`purr` includes a simple tool to help select the device serial from `adb devices`, or can read from the `$ANDROID_SERIAL` environment variable if set. Otherwise, `purr` has the following command-line parameters:
 
 * -a: Sets custom parameters for `adb` that will be used as well as the defaults whenever an input stream is selected.
 * -f: Sets custom parameters for `fzf`. Used on top of default parameters.
@@ -51,6 +51,12 @@ Support for Windows may be provided in future, but is not a current priority.
 * -q: Set the default query string upon `purr` being opened.
 * -v: Shows the `purr` version.
 * -V: Shows a composite version of `purr` and dependencies.
+
+There are also the following special command line parameters that should only be used for testing and debugging:
+
+* -A: Replace all calls to `adb` with the given binary. This can be used in conjunction with the bundled `adb_mock` binary to perform basic testing on purr.
+* -D: Use the given directory to store all generated files instead of the standard /tmp dir.
+* -X: Do not execute `fzf` when reached in the execution loop; return as if `fzf` executed correctly.
 
 Any other command-line parameters will print the help dialog.
 

--- a/makefile
+++ b/makefile
@@ -7,8 +7,9 @@ PURRFILE ?=$(OUTDIR)/purr
 PURRFILE_TEMP ?=$(OUTDIR)/purr_temp
 
 ADBMOCKFILE ?=$(OUTDIR)/adb_mock
+FILETESTERFILE ?=$(OUTDIR)/file_tester
 
-all: purr adb_mock
+all: purr adb_mock file_tester
 
 .PHONY: purr
 
@@ -83,6 +84,16 @@ adb_mock:
 	cat $(TESTDIR)/mocks/adb_mock.sh >> "$(ADBMOCKFILE)"
 
 	chmod +rwx $(ADBMOCKFILE)
+
+.PHONY: file_tester
+
+file_tester:
+	mkdir -p $(OUTDIR)
+	echo "" > $(FILETESTERFILE)
+
+	cat $(TESTDIR)/tester/validate_files.sh >> "$(FILETESTERFILE)"
+
+	chmod +rwx $(FILETESTERFILE)
 
 .PHONY: clean
 

--- a/src/execution_loop.sh
+++ b/src/execution_loop.sh
@@ -31,8 +31,11 @@ while true; do
 
 	__purr_set_start_preview
 
-	# Starts and runs the actual fzf process.
-	if [ ! -z $cached_query ]; then
+	if [[ "$fzf_exec_flag" = "false" ]]; then	# Don't exec fzf if in a testing session.
+		sleep 5
+		accepted=""
+		ret=$?
+	elif [ ! -z $cached_query ]; then 	# Starts and runs the actual fzf process.
 		accepted=$(FZF_DEFAULT_COMMAND="$load_input_stream" fzf $starter_preview_command $fzfp $fzf_prompt $bind_commands $start_command --query=$cached_query)
 		ret=$?
 	else

--- a/src/shell/argument_parsing.sh
+++ b/src/shell/argument_parsing.sh
@@ -47,13 +47,19 @@ __purr_get_composite_version() {
 # Parse argument flags.
 instruction_flag=true
 adb_cmd_loc="adb"
-while getopts ':A:a:f:ivVq:' flags; do
+delete_dir_flag=true
+fzf_exec_flag=true
+while getopts ':XA:D:a:f:ivVq:' flags; do
 	case $flags in
 	q) query_string="--query=${OPTARG}" ;;
 	a) custom_adb_params=${OPTARG} ;;
 	A) adb_cmd_loc=${OPTARG} ;;
+	D)
+		delete_dir_flag=false
+		dir_name=${OPTARG} ;;
 	f) custom_fzf_params=${OPTARG} ;;
 	i) instruction_flag=false ;;
+	X) fzf_exec_flag=false ;;
 	v)
 		echo $VERSION
 		exit 0

--- a/src/shell/shell_env_init.sh
+++ b/src/shell/shell_env_init.sh
@@ -14,7 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dir_name=$(mktemp -d /tmp/purr.XXXXXXXXXX)
+if [ -z $dir_name ]; then
+	dir_name=$(mktemp -d /tmp/purr.XXXXXXXXXX)
+else
+	mkdir -p $dir_name
+fi
 
 # Run cleanup if we exit abnormally.
 trap "__purr_cleanup $dir_name" INT TERM

--- a/src/threads/thread_interface.sh
+++ b/src/threads/thread_interface.sh
@@ -31,7 +31,7 @@ __purr_cleanup() {
 	fi
 
 	# Delete all of the cached state files.
-	if [ -d $dir_name ]; then
+	if [ -d $dir_name ] && [[ $delete_dir_flag = "true" ]]; then
 		rm -r $dir_name &>/dev/null
 	fi
 }

--- a/tests/tester/validate_files.sh
+++ b/tests/tester/validate_files.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env zsh
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mocked_adb_output=$(cat <<-END
+		--------- beginning of system
+		11-30 11:51:17.111   520   565 V DisplayPowerController2[0]: Brightness [0.39763778] reason changing to: 'manual', previous reason: 'manual [ dim ]'.
+		11-30 11:51:17.111   520   565 I DisplayPowerController2[0]: BrightnessEvent: disp=0, physDisp=local:4619827259835644672, brt=0.39763778, initBrt=0.05, rcmdBrt=NaN, preBrt=NaN, lux=0.0, preLux=0.0, hbmMax=1.0, hbmMode=off, rbcStrength=0, thrmMax=1.0, powerFactor=1.0, wasShortTermModelActive=false, flags=, reason=manual, autoBrightness=false, strategy=InvalidBrightnessStrategy
+		--------- beginning of main
+		11-30 11:51:17.159   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff101010
+		11-30 11:51:17.186   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff111111
+		11-30 11:51:17.197   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff121212
+		11-30 11:51:17.214   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff131313
+		11-30 11:51:17.231   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff141414
+		11-30 11:51:17.247   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff151515
+		11-30 11:51:17.264   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff161616
+		11-30 11:51:17.281   397   397 I android.hardware.lights-service.example: Lights setting state for id=1 to color ff171717
+	END
+)
+
+validate_runtime_purr_files() {
+	dir_name=$1
+
+	# Did we load the serial?
+	grep -q -- "emulator-5554" $dir_name/serial-cache.purr
+	grep -q -- "emulator-5554" $dir_name/connection-state.purr
+	echo "Serial was loaded."
+
+	# Did the input stream load to verbose?
+	grep -q -- "verbose-input-cache.purr" $dir_name/input-stream.purr
+	grep -q -- "Verbose" $dir_name/stream-header.purr
+	echo "Input stream is verbose."
+
+	# Is the handler processing IO?
+	if [ -s $dir_name/background-handler-IO.purr ]; then
+		return 1
+	else
+		echo "Thread IO working."
+	fi
+
+	# Did we start on the instruction preview? And it is visible?
+	grep -q -- "instruction" $dir_name/preview-command-cache.purr
+	grep -q -- "nohidden" $dir_name/preview-visibility-cache.purr
+	echo "Preview set to instruction."
+
+	# Did we start with our modes in the correct states?
+	grep -q -- "Off" $dir_name/purr_unique_cache.purr
+	grep -q -- "Off" $dir_name/scroll-lock-header.purr
+	grep -q -- "Chronological" $dir_name/sort-header.purr
+	echo "Modes set to correct starting states."
+
+	# Did purr correctly pick up the adb output?
+	verbose_cache_contents=$(cat $dir_name/verbose-input-cache.purr)
+	if [[ "$verbose_cache_contents" = "$mocked_adb_output" ]]; then
+		echo "Verbose cache is correct."
+	else
+		return 1
+	fi
+}
+
+validate_exit_time_purr_files() {
+	dir_name=$1
+
+	# Has the handler been told to clean up?
+	grep -q -- "purr_thread_cleanup" $dir_name/background-handler-IO.purr
+	echo "Threads are in cleanup."
+
+	# Did the handler actually do clean up?
+	if [ ! -f $dir_name/verbose-input-cache.purr ]; then
+		echo "Threads did actually cleanup."
+	else
+		return 1
+	fi
+}
+
+while getopts ':p:a:' flags; do
+	case $flags in
+		p) purr_binary_path=${OPTARG} ;;
+		a) adb_mock_path=${OPTARG} ;;
+	esac
+done
+
+if [ -z $purr_binary_path ]; then
+	>&2 echo "Please provide the path to the purr binary through -p."
+	exit 1
+elif [ -z $adb_mock_path ]; then
+	>&2 echo "Please provide the path to the adb mock binary through -a."
+	exit 1
+fi
+
+dir_name=$(mktemp -d /tmp/purr.XXXXXXXXXX)
+
+set -e
+
+{
+	eval "$purr_binary_path -A $adb_mock_path -D $dir_name -X"
+} &
+
+sleep 1
+
+validate_runtime_purr_files $dir_name
+
+sleep 5
+
+validate_exit_time_purr_files $dir_name
+
+echo "Files looks valid!"


### PR DESCRIPTION
Should be useful for onboarding to package managers. Does non-trivial testing on the files, but doesn't actually launch fzf.
