### PR TITLE
Don't rely on sed in-place behavior when removing comments

### DIFF
--- a/makefile
+++ b/makefile
@@ -70,7 +70,8 @@ purr:
 	cat $(SRCDIR)/execution_loop.sh >> "$(PURRFILE_TEMP)"
 
 	# Remove comments/shebangs.
-	sed -i -e '/^[ \t]*#/d' "$(PURRFILE_TEMP)"
+	sed -e '/^[ \t]*#/d' "$(PURRFILE_TEMP)" > $(PURRFILE)
+	mv $(PURRFILE) "$(PURRFILE_TEMP)"
 
 	# Add one shebang and the copyright notice.
 	# We need a temp file since cat can't do it in-place.
@@ -92,7 +93,8 @@ adb_mock:
 	cat $(TESTDIR)/mocks/adb_mock.sh >> "$(ADBMOCKFILE_TEMP)"
 
 	# Remove comments/shebangs.
-	sed -i -e '/^[ \t]*#/d' "$(ADBMOCKFILE_TEMP)"
+	sed -e '/^[ \t]*#/d' "$(ADBMOCKFILE_TEMP)" > $(ADBMOCKFILE)
+	mv $(ADBMOCKFILE) "$(ADBMOCKFILE_TEMP)"
 
 	# Add one shebang and the copyright notice.
 	# We need a temp file since cat can't do it in-place.
@@ -114,7 +116,8 @@ file_tester:
 	cat $(TESTDIR)/validators/file_validator.sh >> "$(FILETESTERFILE_TEMP)"
 
 	# Remove comments/shebangs.
-	sed -i -e '/^[ \t]*#/d' "$(FILETESTERFILE_TEMP)"
+	sed -e '/^[ \t]*#/d' "$(FILETESTERFILE_TEMP)" > $(FILETESTERFILE)
+	mv $(FILETESTERFILE) "$(FILETESTERFILE_TEMP)"
 
 	# Add one shebang and the copyright notice.
 	# We need a temp file since cat can't do it in-place.


### PR DESCRIPTION
For context - this arose out of https://github.com/Homebrew/homebrew-core/pull/182308, where it was noticed that the build output differs when building `purr` on macOS vs Linux, which was unexpected since `purr` does not involve any platform-specific compiled code (i.e. it's all text, portable shell script). The only difference noticed was that the comment removal using `sed` was occurring on Linux but not occurring on macOS.

Not all variants of `sed` support the `-i` flag for editing a file in-place. Notably, GNU `sed` supports the flag but the `sed` found on macOS and BSDs doesn't support it. The [POSIX specification for `sed`](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/sed.html) does not include the flag.

The command is only responsible for removing comments from the file, so the failure does not break anything, but for packagers that package across multiple platforms (e.g. Homebrew), it is preferred that the comments are included/excluded in the build output consistently across platforms (for reproducibility purposes).

Other possible solutions to consider:
- Use a different tool to edit the file which can operate in-place consistently between platforms, such as `perl` or `ed`
- Expose a makefile variable, e.g. `SED`, to allow a packager to pass in the path of a compliant `sed`
  - Not as nice since it still imposes a build requirement on GNU `sed` to get consistent results, but preferable to the current situation of requiring that the first `sed` on `PATH` is GNU `sed`